### PR TITLE
English, dumbfuck

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 cPanel Login for MOFH is a login/signup template using cPanel design to bring the cPanel experience to your reseller.  
 
 ## How to install it?  
-You just need to download it from [here](https://github.com/DrastDev/cPanel-Login-for-MOFH/archive/master.zip) and extract it's contents.  
+You just need to download it from [here](https://github.com/DrastDev/cPanel-Login-for-MOFH/archive/master.zip) and extract its contents.  
 Then, copy and paste them on your site and the template should be installed!  
 
 Don't forget to replace any links with the new login and signup links.  


### PR DESCRIPTION
It is "its", not "it's" because "it's" is the contraction of "it is" whereas "its" is possessive.